### PR TITLE
Added setting for retrigger-gap on gate-output

### DIFF
--- a/src/Phaseque.cpp
+++ b/src/Phaseque.cpp
@@ -1011,7 +1011,7 @@ void Phaseque::process(const ProcessArgs& args) {
             outputs[STEP_GATE_OUTPUT + this->pattern.activeStepIdx].setVoltage(10.f);
         }
 
-        bool retrigGap = retrigGapGenerator.process(sampleTime);
+        bool retrigGap = retrigGapGate && retrigGapGenerator.process(sampleTime);
         outputs[GATE_OUTPUT].setVoltage(this->clutch && this->pattern.hasActiveStep && !retrigGap ? 10.f : 0.f);
     } else if (this->polyphonyMode == PolyphonyModes::POLYPHONIC) {
         this->pattern.findStepsForPhase(this->phaseShifted, this->globalGate);

--- a/src/Phaseque.hpp
+++ b/src/Phaseque.hpp
@@ -264,6 +264,7 @@ struct Phaseque : Module {
     /* Settings */
     bool useCompatibleBPMCV = true;
     bool snapCV = false;
+    bool retrigGapGate = true;
 
     void setPolyMode(PolyphonyModes polyMode);
     void goToPattern(unsigned int targetIdx);
@@ -667,6 +668,7 @@ struct Phaseque : Module {
         this->patternIdx = 0;
         this->takeOutCurrentPattern();
         this->polyphonyMode = PolyphonyModes::MONOPHONIC;
+        this->retrigGapGate = true;
     }
 
     void onRandomize() override {
@@ -687,6 +689,7 @@ struct Phaseque : Module {
         json_object_set_new(rootJ, "polyphonyMode", json_integer(polyphonyMode));
         json_object_set_new(rootJ, "useCompatibleBPMCV", json_boolean(useCompatibleBPMCV));
         json_object_set_new(rootJ, "snapCV", json_boolean(snapCV));
+        json_object_set_new(rootJ, "retrigGapGate", json_boolean(retrigGapGate));
 
         json_t* patternsJ = json_array();
         json_array_append_new(patternsJ,
@@ -724,6 +727,7 @@ struct Phaseque : Module {
         json_t* polyphonyModeJ = json_object_get(rootJ, "polyphonyMode");
         json_t* useCompatibleBPMCVJ = json_object_get(rootJ, "useCompatibleBPMCV");
         json_t* snapCVJ = json_object_get(rootJ, "snapCV");
+        json_t* retrigGapGateJ = json_object_get(rootJ, "retrigGapGate");
 
         if (tempoTrackJ) {
             this->tempoTrack = json_boolean_value(tempoTrackJ);
@@ -768,6 +772,10 @@ struct Phaseque : Module {
 
         if (snapCVJ) {
             snapCV = json_boolean_value(snapCVJ);
+        }
+
+        if (retrigGapGateJ) {
+            retrigGapGate = json_boolean_value(retrigGapGateJ);
         }
 
         if (patternsJ) {

--- a/src/PhasequeWidget.cpp
+++ b/src/PhasequeWidget.cpp
@@ -239,6 +239,9 @@ void PhasequeWidget::appendContextMenu(Menu* menu) {
     menu->addChild(phaseqClearPatternItem);
     menu->addChild(new MenuSeparator());
 
+    menu->addChild(createBoolPtrMenuItem("Retrigger Gate between active steps", "", &phaseq->retrigGapGate));
+    menu->addChild(new MenuSeparator());
+
     PolyModeItem* polyModeItem = new PolyModeItem;
     polyModeItem->text = "Polyphony";
     polyModeItem->rightText = RIGHT_ARROW;


### PR DESCRIPTION
This is intended behaviour, as an "gap" is explicitly inserted after at the beginning of gate for re-triggering in monophonic mode.
https://github.com/zezic/ZZC-Phaseque/blob/b069fc4a416ffd5ea3f96b6109f0a0c027764759/src/Phaseque.cpp#L1014
The pull request adds a context menu setting for #19.